### PR TITLE
Move CSS and JS scripts to template for create true overrides

### DIFF
--- a/modules/mod_spsimpleportfolio/mod_spsimpleportfolio.php
+++ b/modules/mod_spsimpleportfolio/mod_spsimpleportfolio.php
@@ -9,8 +9,6 @@
 
 defined('_JEXEC') or die;
 
-use Joomla\CMS\Factory;
-use Joomla\CMS\Uri\Uri;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Helper\ModuleHelper;
 use Joomla\CMS\Component\ComponentHelper;
@@ -21,13 +19,6 @@ require_once __DIR__ . '/helper.php';
 HTMLHelper::_('jquery.framework');
 BaseDatabaseModel::addIncludePath(JPATH_SITE . '/components/com_spsimpleportfolio/models');
 require_once JPATH_BASE . '/components/com_spsimpleportfolio/helpers/helper.php';
-
-$doc = Factory::getDocument();
-$doc->addStylesheet( Uri::root(true) . '/components/com_spsimpleportfolio/assets/css/featherlight.min.css' );
-$doc->addStylesheet( Uri::root(true) . '/components/com_spsimpleportfolio/assets/css/spsimpleportfolio.css' );
-$doc->addScript( Uri::root(true) . '/components/com_spsimpleportfolio/assets/js/jquery.shuffle.modernizr.min.js' );
-$doc->addScript( Uri::root(true) . '/components/com_spsimpleportfolio/assets/js/featherlight.min.js' );
-$doc->addScript( Uri::root(true) . '/components/com_spsimpleportfolio/assets/js/spsimpleportfolio.js' );
 
 $cParams      = ComponentHelper::getParams('com_spsimpleportfolio');
 

--- a/modules/mod_spsimpleportfolio/tmpl/default.php
+++ b/modules/mod_spsimpleportfolio/tmpl/default.php
@@ -9,7 +9,16 @@
 
 defined('_JEXEC') or die;
 
+use Joomla\CMS\Factory;
+use Joomla\CMS\Uri\Uri;
 use Joomla\CMS\Language\Text;
+
+$doc = Factory::getDocument();
+$doc->addStylesheet( Uri::root(true) . '/components/com_spsimpleportfolio/assets/css/featherlight.min.css' );
+$doc->addStylesheet( Uri::root(true) . '/components/com_spsimpleportfolio/assets/css/spsimpleportfolio.css' );
+$doc->addScript( Uri::root(true) . '/components/com_spsimpleportfolio/assets/js/jquery.shuffle.modernizr.min.js' );
+$doc->addScript( Uri::root(true) . '/components/com_spsimpleportfolio/assets/js/featherlight.min.js' );
+$doc->addScript( Uri::root(true) . '/components/com_spsimpleportfolio/assets/js/spsimpleportfolio.js' );
 
 $layout_type = $params->get('layout_type', 'default');
 ?>


### PR DESCRIPTION
Currently the pages must be fast, and better if it makes few requests to the server.

Loading embedded videos from youtube or vimeo on a website increases requests (approximately 11); so trying to reduce that I created an everride of the module, to eliminate the previews of the video, which was obtained as expected. But the module still continued to load the featherlight.min.js and featherlight.min.css files, when they were no longer needed, and the loading of those files could not be nulled because an override of the mod_spsimpleportfolio.php file cannot be created. Do the same if you want to switch to another preview script.

These changes that I am proposing solve that problem by giving better control over the files from the override.